### PR TITLE
document default login

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ and push your operator image to quay.io to make it available for installation.
 8. Expose the new IQ Server outside the cluster: 
    2. Create a Route in OpenShift UI to the new service, port 8070.
 9. Visit the new URL shown on the Route page in OpenShift UI.
+10. Default credentials are admin/admin123.
   
 ## Uninstall Nexus IQ from a Local Test Cluster
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ and push your operator image to quay.io to make it available for installation.
 8. Expose the new IQ Server outside the cluster: 
    2. Create a Route in OpenShift UI to the new service, port 8070.
 9. Visit the new URL shown on the Route page in OpenShift UI.
-10. Default credentials are admin/admin123.
+10. Default credentials are `admin`/`admin123`.
   
 ## Uninstall Nexus IQ from a Local Test Cluster
 

--- a/scripts/templates/nxiq-operator-certified.vX.X.X-X.clusterserviceversion.yaml
+++ b/scripts/templates/nxiq-operator-certified.vX.X.X-X.clusterserviceversion.yaml
@@ -141,8 +141,8 @@ spec:
     Once the server instance is created by the operator and running,
     you'll want to expose the service as you see fit:
     1. Create a Route to the new service for iq.applicationPort (8070).
-    2. Visit the URL provided by the Route, and login with the default credentials:
-      `admin`/`admin123`
+    2. Visit the URL provided by the Route, login, and set new credentials.
+      The default credentials are `admin`/`admin123`.
 
     The Nexus IQ Server can be further configured via the NexusIQ custom resource definition:
 

--- a/scripts/templates/nxiq-operator-certified.vX.X.X-X.clusterserviceversion.yaml
+++ b/scripts/templates/nxiq-operator-certified.vX.X.X-X.clusterserviceversion.yaml
@@ -141,6 +141,8 @@ spec:
     Once the server instance is created by the operator and running,
     you'll want to expose the service as you see fit:
     1. Create a Route to the new service for iq.applicationPort (8070).
+    2. Visit the URL provided by the Route, and login with the default credentials:
+      `admin`/`admin123`
 
     The Nexus IQ Server can be further configured via the NexusIQ custom resource definition:
 


### PR DESCRIPTION
IBM contacts suggested documenting the default logins to assist in initial setup and test.

Build: https://jenkins.ci.sonatype.dev/job/integrations/job/cloud/job/operator-iq/job/feature-snapshots/job/document-default-logins/