### PR TITLE
INT-4823 upgrade to ship IQ 107

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,11 +41,11 @@ node('ubuntu-zion') {
   }
 
   stage('Build') {
-    //OsTools.runSafe(this, 'scripts/bundle.sh')
+    // OsTools.runSafe(this, 'scripts/bundle.sh')
   }
 
   stage('Archive') {
-      archiveArtifacts artifacts: archiveName, onlyIfSuccessful: true
+    // archiveArtifacts artifacts: archiveName, onlyIfSuccessful: true
   }
 }
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -5,7 +5,7 @@ FROM quay.io/operator-framework/helm-operator:v0.17.0
 # Required OpenShift Labels
 LABEL name="Nexus IQ Server Operator" \
       vendor="Sonatype" \
-      version="1.100.0" \
+      version="1.107.0" \
       release="1" \
       summary="Nexus IQ Server is a policy engine powered by precise intelligence on open source components." \
       description="Nexus IQ Server is a policy engine powered by precise intelligence on open source components."

--- a/deploy/crds/sonatype.com_v1alpha1_nexusiq_cr.yaml
+++ b/deploy/crds/sonatype.com_v1alpha1_nexusiq_cr.yaml
@@ -32,7 +32,7 @@ spec:
         - port: 8070
           type: http
       sonatypeWork: /sonatype-work
-    imageName: registry.connect.redhat.com/sonatype/nexus-iq-server:1.100.0-ubi-2
+    imageName: registry.connect.redhat.com/sonatype/nexus-iq-server:1.107.0-ubi-1
     imagePullPolicy: IfNotPresent
     imagePullSecret: ""
     licenseSecret: ""

--- a/deploy/olm-catalog/nxiq-operator-certified/1.107.0-1/nxiq-operator-certified.v1.107.0-1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/nxiq-operator-certified/1.107.0-1/nxiq-operator-certified.v1.107.0-1.clusterserviceversion.yaml
@@ -1,0 +1,372 @@
+# DO NOT MODIFY. This is produced by template.
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "sonatype.com/v1alpha1",
+          "kind": "NexusIQ",
+          "metadata": {
+            "name": "example-nexusiq"
+          },
+          "spec": {
+            "deployment": {
+              "postStart": {
+                "command": null
+              },
+              "preStart": {
+                "command": null
+              }
+            },
+            "fullnameOverride": "",
+            "imagePullSecrets": [],
+            "ingress": {
+              "annotations": {},
+              "enabled": false,
+              "hosts": [],
+              "path": "/",
+              "tls": []
+            },
+            "iq": {
+              "adminPort": 8071,
+              "applicationPort": 8070,
+              "configYaml": {
+                "createSampleData": true,
+                "server": {
+                  "adminConnectors": [
+                    {
+                      "port": 8071,
+                      "type": "http"
+                    }
+                  ],
+                  "applicationConnectors": [
+                    {
+                      "port": 8070,
+                      "type": "http"
+                    }
+                  ]
+                },
+                "sonatypeWork": "/sonatype-work"
+              },
+              "imageName": "registry.connect.redhat.com/sonatype/nexus-iq-server:1.107.0-ubi-1",
+              "imagePullPolicy": "IfNotPresent",
+              "imagePullSecret": "",
+              "licenseSecret": "",
+              "memory": "1Gi",
+              "name": "nxiq"
+            },
+            "nameOverride": "",
+            "persistence": {
+              "accessMode": "ReadWriteOnce",
+              "storageSize": "1Gi"
+            },
+            "service": {
+              "annotations": {},
+              "enabled": false,
+              "labels": {},
+              "ports": [
+                {
+                  "name": "nexus-service",
+                  "port": 80,
+                  "targetPort": 80
+                }
+              ]
+            },
+            "serviceAccount": {
+              "create": true,
+              "name": null
+            }
+          }
+        }
+      ]
+    capabilities: Basic Install
+    categories: "Security"
+    description: |-
+      Nexus Lifecycle is an open source governance platform that continuously identifies risk,
+      automatically enforces policy, and provides visibility throughout the entire SDLC.
+    containerImage: registry.connect.redhat.com/sonatype/nxiq-operator-certified:1.107.0-1
+    repository: https://github.com/sonatype/operator-iq
+    createdAt: 2020-07-20
+    support: Sonatype
+    certified: "true"
+  name: nxiq-operator-certified.v1.107.0-1
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - kind: NexusIQ
+      name: nexusiqs.sonatype.com
+      version: v1alpha1
+      description: Nexus IQ Server
+      displayName: NexusIQ
+  description: |-
+    Nexus Lifecycle is an open source governance platform that continuously identifies risk,
+    automatically enforces policy, and provides visibility throughout the entire SDLC.
+    Developers leveraging open source require a solution that helps them make safer choices
+    while still delivering at DevOps speed.
+    Nexus Lifecycle empowers developers and security teams to choose the best components
+    and govern open source usage, ensuring organizations continue to innovate with less risk.
+
+    ## Core Capabilities
+
+    * **Dependency Management**:
+      Generate a precise software bill of materials for all applications
+      to identify open source components and gather contextual direct
+      and transitive dependency information for faster action.
+    * **One-Click Remediation**:
+      Upgrade to the best components and versions based on real-time intelligence.
+      Available in your preferred IDE or a GitHub pull request.
+    * **Automated Open Source Policy Enforcement**:
+      Create custom security, license, and architectural policies based
+      on application type or organization and contextually enforce those policies
+      across every stage of the SDLC.
+    * **Continuous Monitoring**:
+      Real-time notifications of newly discovered defects,
+      as well as vulnerabilities based on component,
+      risk level or application/container affected.
+
+    ## Extras
+
+    * IDE Integrations: Eclipse, IntelliJ, and Visual Studio
+    * Source Control Integrations: GitHub, GitLab, and Bitbucket
+    * Chrome Browser Extension
+    * Red Hat Clair for Container Scanning
+
+
+    ## Usage
+
+    Once the server instance is created by the operator and running,
+    you'll want to expose the service as you see fit:
+    1. Create a Route to the new service for iq.applicationPort (8070).
+    2. Visit the URL provided by the Route, login, and set new credentials.
+      The default credentials are `admin`/`admin123`.
+
+    The Nexus IQ Server can be further configured via the NexusIQ custom resource definition:
+
+    | Parameter            | Description                                                  | Default           |
+    | -------------------- | ------------------------------------------------------------ | ----------------- |
+    | `iq.applicationPort` | Port of the application connector. Must match the value in the `configYaml` property | `8070`            |
+    | `iq.adminPort`       | Port of the application connector. Must match the value in the `configYaml` property | `8071`            |
+    | `iq.memory`          | The amount of RAM to allocate                                | `1Gi`             |
+    | `iq.licenseSecret`   | The base-64 encoded license file to be installed at startup  | `""`              |
+    | `iq.configYaml`      | A YAML block which will be used as a configuration block for IQ Server. | See example YAML shown when creating a NexusIQ. |
+    | `ingress.enabled`                           | Create an ingress for Nexus         | `true`                                  |
+    | `ingress.annotations`                       | Annotations to enhance ingress configuration  | `{}`                          |
+    | `ingress.tls.enabled`                       | Enable TLS                          | `true`                                 |
+    | `ingress.tls.secretName`                    | Name of the secret storing TLS cert, `false` to use the Ingress' default certificate | `nexus-tls`                             |
+    | `ingress.path`                              | Path for ingress rules. GCP users should set to `/*` | `/`                    |
+    | `deployment.preStart.command`               | Command to run before starting the IQ Server container  | `nil`                   |
+    | `deployment.postStart.command`              | Command to run after starting the IQ Server container  | `nil`                    |
+    | `deployment.terminationGracePeriodSeconds` | Time to allow for clean shutdown                        | 120                      |
+    | `persistence.storageClass` | The provisioner class                        | `-` (disables dynamic provisioning)            |
+    | `persistence.storageSize` | The amount of drive space to allocate                        | `1Gi`             |
+    | `persistence.accessMode` | Default access mode                        | `ReadWriteOnce`             |
+    | `persistence.volumeConfiguration` | A YAML block to configure the persistent volume type. Defaults to `hostPath` which should not be used in production | `hostPath`             |
+
+    ## Configuring IQ Server
+
+    You can define the `config.yml` for IQ Server in your CRD on startup. 
+    It is the `iq.configYaml` property. For more details, see the [Configuring IQ Server](https://help.sonatype.com/iqserver/configuring) help page.
+
+
+    ## Installing the License
+
+    The license file can be installed via the UI when IQ server is running, or it can be done as a part of the deploy. 
+    If you leave the `licenseFile` field empty/commented, IQ Server will start and prompt you to manually install the license 
+    when you first enter the GUI.
+
+    ### Installing the License Automatically
+    To do it automatically, first encode your `.lic` file in Base 64 with no line breaks, eg:
+
+    ```bash
+    base64 --wrap=0 mylicense.lic > lic.base64
+    ```
+
+    Then add this value to your CRD file as `iq.licenseSecret`, eg:
+
+    ```yaml
+    iq:
+      licenseSecret: bXkgc2FtcGxlIGxpY2Vuc2U=
+    ```
+
+    Specify the `licenseFile` path in `iq.configYaml` as:
+
+    ```yaml
+    iq:
+      configYaml:
+        server:
+          applicationConnectors:
+            - type: http
+              port: 8070
+          adminConnectors:
+            - type: http
+              port: 8071
+        createSampleData: true
+        sonatypeWork: /sonatype-work
+        # add this line and the `licenseSecret` above to autoconfigure licensing
+        licenseFile: /etc/nexus-iq-license/license_lic
+    ```
+  displayName: Nexus IQ Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAHAAAACACAYAAADTcu1SAAAACXBIWXMAACE3AAAhNwEzWJ96AAAJoklEQVR4nO2dO1IbSxSG265bpVDOrwomvgrQXYF1V2C8AvAKLIdEFpFCixUgVmC8AssrsAiILalYgBUS+VZTf1OD5tXP030avioSjxEz+qf7PLv71Z8/f0RObHuzqRDi+uD+bFV+rEExHAkh1nfr2985Pe/ryr8wZdubHW97s7UQ4rMQ4k3NUxwLIVaDYnhaucKYvzIQrhBCLIQQbysXqxwKIS4h4uRufbuq/A9msBVw25vJUSany4+Vi91IsX8OiuEVhGQ7rbKcQre92UTaM0vxypzIzxkUw2nlChNYjcBtbzbGdHlYuWhPX9rN0rR6Tf1cLrAQEHZuLoR4V7noD/lSfB0Uwx9CiNO79e2a+jltSFpA2LkJPEsqpH38NSiGF9LGpm4fk7WB297sFHaOUrwyH2EfJ5UrCZGcgNLObXsz6d5fwj7FRP79L4NiKIUcR76XWpKZQmHnpvAMU0Pax+8p2sfoApbs3CSBEdeFso/n0qlKwT5GnUJh51awc6mLV+Yz7GP0tFwUAbe92Wjbmy1h53zGdJT0kZZbxbSPpFMopst5onbOliPYx29IBJDaR7IRiDLPOjPxyrxDtWM6KIZ11ZAgBBdwr8xDYeeuYFf3oRgZfTwnWdkqWEHXsMzjA+niTw/uz5ZNn4Wi7pz6nu7Wt4335Ip3AR3LPDZsINxC93cHxfAYQlI5UFcQ0vss4FVAlHmmhCHBQzx2cH9mFY+hjEQVf+4QO3otXXkRMFCZp40Hj+/g/sz5jR4UQ+oM0MZn2cpJwAh27gbCebcpiOWmxPbRua3DSsAIZZ4dhNO2c7bAe5wS20frtg5jAZH+mhPauQs4KWR5R8Rx1C+odHLmlSsdaAsIOzdH5oGCh8y/DztnC+xj6E6AMhtUO7RNRKeARO0MZTYQLljsZArsI/nLqxN2NAoYocyzw1RpPI1QAftIbj7a7GOtgLBz5Iac0s7ZAvtImahotY9PBISdI3el99cxcAD2kTyE2rePjwJCvO+VXwvDBsKx6sGsA/aRPImh7CP1CNwh9cW2E7oJdK+RpxHbbKBvY30FJ4VFw6wNEezjea2Awm+2pbPMkxuEZatmARUOcaBxmSc3CMpW56/+PvxHTpfXbbGGMM/EOJV5ciNg2epBQDm1jXRrVR320VuZJzdgH303dD0KqOZqrVpVTdU9WJknNzyXrSoCKrRqVbCP4+ds52zxVLZqFFDBfglyypTKVrb28byrrfCEwxIrrsiBAb/DugVRpy80+SVWGWA9w5m01ie7xEoXuSajYQ8ZyZqj92yzNkItsfrXtCFn25vNEbK04a06IbvCpZOFn874ddubCThw0gtfcqiSuCxuaXqT2xi1OEwun/sIPOMJ7IqNY/BW3eO2N7tBQiJZLzunrbbeYIT/QnzqI+shR+2lXNuBBEZyZCEgpkofG/80cQghl0hiJAN7ATHqvhLV4eTUuoYzlASsBdz2ZgvC2ptCvijLVKZUtgJCvFiLRfuYUqOPRK6b3bksRtkgVCj/2LKE1xsNdttNoi5p2iVwg1LOsilYx2g6NQw/+ogZo41EjiPQJCaTTVTvD+7PRjKWaxJPIoP2g/szGT8WaKjV5QgzQhRYCYgFpLrlFznqCtPWRdlFACHf4wXQYRIrvOA2AnWrIjeoU1oniSG8bvK+b3BvXmEjINx2ndG3cxVPgVzop8qFel4E7OC4/fIjXtdYYLGNjqfaR0aIFBYCwr7otDXeBEo86zopLwI2oGuLalfwuIJmrRuP9+kNLgLqxlkhF8vojOxD6sA+pxH4I3AjsW7L5IuAlgStnhtU50mzMjlNoRStjzp2kDSg5yKgTm6yMU3mkeT6Y3OaQp9l83FOAiZTJaeEi4AuNTsjsEFtkx2j2tBAm5xGoHMQXeqvqSQEDOI70hVaXATUceGtp1C0JC5L/TUnNTU+3ReE1BbnJKBVMhmV+FXN9Ph5r3FJ57N31N3cXFoqdKeliUk6DYIvWsKUS5zj9FszmU6+wJXFCEQrhE4Q/RY9M51APJ1+0qVBGwf5xkWcnBjdL7HigDSwRIdaF/2a6bWJFwFbWGj2qByhZ7QVJL6PDfpeuriKsSsHGwHx5eiOrhNNEVcei7BROtO4xYFzgxFzgsUorfEbirUfKhfMuGhrWQwJKwExCk2ahx4Wo8rR2NYGjzYMk17QMrtYo09w7MyWXzY8TZPW+hOMyA1ivv1YbeyQCDiOuSMVOwHBBF+46R7Wh/jxtf/3p9ibG7HMheKNl6NGJzYMyWlL4psEtsnsREQ8ipF9KcO6GoF1DCMHB8QHWnFnKLIoJ2Exyn8RR+M41jrBbOqB0pnAaPzgWciuz5LF5lGsOJDaC9UptTi55IjpFqUFm1qb/OzxTSWx5TSNWmFdPlSmz6KulScVEFMd1d9aqaAfnuIIP01e4wrbbdW9ZMcQtPwifEhhAyCucaAR8FiXth4jRuG41Lo4bhCanJx6YoJSCltGKe2h5jICJ4NiuHpOm8GGEK50BKwVLiPwHTaDze4UFgrkbr2DYqj2dqtzkLRwnUIfDr7HZrDkixu5gh2Qvezt5suJkQnir9gM1vlg31wJcVCWbydGTgU/5dSADb1fgJ0bFMNrnA7n9RSXUF7ox5fN0h/t3BR2LsgRtiHDiGe9WTrOhViHPgmbIpBnv1m6CdQHJr82aNdzRW2WPs3RPsLOLWDnKMST7SHLh+PnIh3sK71V9kf2eDh9xZRd+aCyJ+cHpnKwLxc8nX9kQuUopNoDIGMf7Js6hCd0Khrj61oBFQEPLmziHNNDkvnVQGcAtrHBGfKNpqZVwFRvOgbEL/MO33nny9wpoCLStDGNbR8JzsHd5wrPrWVOtAVUpP5Avojwwlo5dMYCKmJMKTpn/LrCLaSyFlA8LUZS2sfOM35tQe52yslpcxJQ4flgXx0a3WobOIdNXgRUpBDYmpBD4sKrgOJpailoFr7EDk6O9m69HO5RF+8CKvB2z0PVwWrYoNrR+nZjlpgT2rkLiBckORFMQAV1eQX2sVK2SuU+fBNcQEWsNx+d2MnNBL4gE1DEsz0it1i1DKmAigjeX2icvGEXogioiBB/+SZ6G2VUARURMiCuBM0ImZCEgCJODtKGKHaujWQEVESoAugSpSrSRXICKiKUrZpIoi7ZRLICKiK0dSiS7AzYJ3kBRZy2jqR7c8qwEFBBYB9ZdccJbgIqApSt2PanshRQ+OuIZt8hzlZAhUNbBxs71wZ7ARUG5aKsVkllI6CipWxFWuahIjsBRbVsFaydIQWyFFAB+/g7271shBD/A2XIzjw5Rp1jAAAAAElFTkSuQmCC
+    mediatype: "image/png"
+  install:
+    spec:
+      deployments:
+      - name: nxiq-operator-certified
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: nxiq-operator-certified
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: nxiq-operator-certified
+            spec:
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: nxiq-operator-certified
+                - name: RELATED_IMAGE_IQ
+                  value: registry.connect.redhat.com/sonatype/nexus-iq-server:1.107.0-ubi-1
+                image: registry.connect.redhat.com/sonatype/nxiq-operator-certified:1.107.0-1
+                imagePullPolicy: Always
+                name: nxiq-operator-certified
+                resources: {}
+              serviceAccountName: nxiq-operator-certified
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - secrets
+          verbs:
+          - '*'
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - nxiq-operator-certified
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          - deployments
+          verbs:
+          - get
+        - apiGroups:
+          - sonatype.com
+          resources:
+          - '*'
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        serviceAccountName: nxiq-operator-certified
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - security
+  - sonatype
+  - licensing
+  - policy
+  - components
+  links:
+  - name: Nexus Lifecycle
+    url: https://www.sonatype.com/product-nexus-lifecycle
+  maintainers:
+  - email: support@sonaype.com
+    name: Sonatype
+  maturity: stable
+  provider:
+    name: Sonatype
+  version: 1.107.0-1
+  replaces: nxiq-operator-certified.v1.100.0-2

--- a/deploy/olm-catalog/nxiq-operator-certified/nxiq-operator-certified.package.yaml
+++ b/deploy/olm-catalog/nxiq-operator-certified/nxiq-operator-certified.package.yaml
@@ -1,6 +1,6 @@
 # DO NOT MODIFY. This is produced by template.
 channels:
-- currentCSV: nxiq-operator-certified.v1.100.0-2
+- currentCSV: nxiq-operator-certified.v1.107.0-1
   name: stable
 defaultChannel: stable
 packageName: nxiq-operator-certified

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: nxiq-operator-certified
           # Replace this with the built image name
-          image: registry.connect.redhat.com/sonatype/nxiq-operator-certified:1.100.0-2
+          image: registry.connect.redhat.com/sonatype/nxiq-operator-certified:1.107.0-1
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
@@ -31,4 +31,4 @@ spec:
             - name: OPERATOR_NAME
               value: "nxiq-operator-certified"
             - name: RELATED_IMAGE_IQ
-              value: registry.connect.redhat.com/sonatype/nexus-iq-server:1.100.0-ubi-2
+              value: registry.connect.redhat.com/sonatype/nexus-iq-server:1.107.0-ubi-1

--- a/helm-charts/iqserver/Chart.yaml
+++ b/helm-charts/iqserver/Chart.yaml
@@ -1,6 +1,6 @@
 # DO NOT MODIFY. This is produced by template.
 apiVersion: v1
-appVersion: 1.100.0
+appVersion: 1.107.0
 description: Sonatype Nexus IQ Server continuously monitors your entire software supply
   chain
 home: https://www.sonatype.com/nexus-iq-server

--- a/helm-charts/iqserver/values.yaml
+++ b/helm-charts/iqserver/values.yaml
@@ -5,7 +5,7 @@
 
 iq:
   name: nxiq
-  imageName: registry.connect.redhat.com/sonatype/nexus-iq-server:1.100.0-ubi-2
+  imageName: registry.connect.redhat.com/sonatype/nexus-iq-server:1.107.0-ubi-1
   imagePullPolicy: IfNotPresent
   imagePullSecret: ""
   applicationPort: 8070


### PR DESCRIPTION
Going for a practice release of IQ 107 until the 108 image is built. All these changes are generated from template for the available versions, so not much to see. Will have jenkins trigger Red Hat build for the operator image, then run the newer bundle.sh locally to push the operator bundle for 107. Then I can publish at red hat.

JIRA: https://issues.sonatype.org/browse/INT-4823
Jenkins: https://jenkins.ci.sonatype.dev/view/all/job/integrations/job/cloud/job/operator-iq/job/feature-snapshots/job/upgrade-107/
