### PR TITLE
INT-4424 remove old steps from jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,14 +39,6 @@ node('ubuntu-zion') {
       }
     }
   }
-
-  stage('Build') {
-    //OsTools.runSafe(this, 'scripts/bundle.sh')
-  }
-
-  stage('Archive') {
-      archiveArtifacts artifacts: archiveName, onlyIfSuccessful: true
-  }
 }
 
 def readVersion() {


### PR DESCRIPTION
* bundle no longer works
* no zip to archive anymore

JIRA: https://issues.sonatype.org/browse/INT-4424 (follow up task)
Jenkins: https://jenkins.ci.sonatype.dev/view/all/job/integrations/job/cloud/job/operator-iq/job/feature-snapshots/job/INT-4424-disable-archive-bundle/
