### PR TITLE
INT-6562 set user agent for server

### DIFF
--- a/helm-charts/iqserver/templates/deployment.yaml
+++ b/helm-charts/iqserver/templates/deployment.yaml
@@ -24,6 +24,9 @@ spec:
       containers:
       - name: {{ template "iqserver.fullname" . }}
         image: {{ .Values.iq.imageName }}
+        env:
+          - name: SONATYPE_INTERNAL_HOST_SYSTEM
+            value: Operator
         ports:
         - containerPort: {{ .Values.iq.applicationPort }}
         lifecycle:


### PR DESCRIPTION
set the user agent for the server, so we can see requests from servers installed via the operator.

updates to use the new image will come with the release task.

JIRA: https://issues.sonatype.org/browse/INT-6562