### PR TITLE
INT-6713 customize env

### DIFF
--- a/helm-charts/iqserver/templates/deployment.yaml
+++ b/helm-charts/iqserver/templates/deployment.yaml
@@ -27,6 +27,9 @@ spec:
         env:
           - name: SONATYPE_INTERNAL_HOST_SYSTEM
             value: Operator
+          - name: SONATYPE_WORK
+            value: {{ .Values.iq.configYaml.sonatypeWork }}
+          {{- toYaml .Values.iq.env | nindent 10 }}
         ports:
         - containerPort: {{ .Values.iq.applicationPort }}
         lifecycle:

--- a/scripts/templates/Dockerfile
+++ b/scripts/templates/Dockerfile
@@ -1,5 +1,5 @@
 # {{templateWarning}}
-FROM quay.io/operator-framework/helm-operator:v1.9.1
+FROM quay.io/operator-framework/helm-operator:v1.18.0
 
 # Required OpenShift Labels
 LABEL name="Nexus IQ Server Operator" \

--- a/scripts/templates/nxiq-operator-certified.clusterserviceversion.yaml
+++ b/scripts/templates/nxiq-operator-certified.clusterserviceversion.yaml
@@ -218,6 +218,7 @@ spec:
     | `iq.applicationPort` | Port of the application connector. Must match the value in the `configYaml` property | `8070`            |
     | `iq.adminPort`       | Port of the application connector. Must match the value in the `configYaml` property | `8071`            |
     | `iq.memory`          | The amount of RAM to allocate                                | `1Gi`             |
+    | `iq.env`             | Customize the server environment, including `JAVA_OPTS`      | See example YAML show when ceating a NexusIQ. |
     | `iq.licenseSecret`   | The base-64 encoded license file to be installed at startup  | `""`              |
     | `iq.configYaml`      | A YAML block which will be used as a configuration block for IQ Server. | See example YAML shown when creating a NexusIQ. |
     | `ingress.enabled`                           | Create an ingress for Nexus         | `true`                                  |

--- a/scripts/templates/nxiq-operator-certified.clusterserviceversion.yaml
+++ b/scripts/templates/nxiq-operator-certified.clusterserviceversion.yaml
@@ -33,6 +33,12 @@ metadata:
             "iq": {
               "adminPort": 8071,
               "applicationPort": 8070,
+              "env": [
+                {
+                  "name": "JAVA"_OPTS,
+                  "value": "-Djava.util.prefs.userRoot=$(SONATYPE_WORK)/javaprefs"
+                }
+              ],
               "configYaml": {
                 "sonatypeWork": "/sonatype-work",
                 "createSampleData": true,

--- a/scripts/templates/sonatype.com_v1alpha1_nexusiq_cr.yaml
+++ b/scripts/templates/sonatype.com_v1alpha1_nexusiq_cr.yaml
@@ -23,6 +23,9 @@ spec:
   iq:
     adminPort: 8071
     applicationPort: 8070
+    env:
+      - name: JAVA_OPTS
+        value: "-Djava.util.prefs.userRoot=$(SONATYPE_WORK)/javaprefs"
     configYaml:
       sonatypeWork: /sonatype-work
       createSampleData: true

--- a/scripts/templates/values.yaml
+++ b/scripts/templates/values.yaml
@@ -11,6 +11,9 @@ iq:
   applicationPort: 8070
   adminPort: 8071
   memory: 1Gi
+  env:
+    - name: JAVA_OPTS
+      value: "-Djava.util.prefs.userRoot=$(SONATYPE_WORK)/javaprefs"
   # base 64 encoded license file with no line breaks
   licenseSecret: ""
   # configYaml is the full text of the config.yml file that will be passed to IQ Server


### PR DESCRIPTION
Allow `iq.env` to be specified when creating NexusIQ instances.

JIRA: https://issues.sonatype.org/browse/INT-6713
Build: N/A for operators