### PR TITLE
INT-6768 set deployment strategy to Recreate

### DIFF
--- a/helm-charts/iqserver/templates/deployment.yaml
+++ b/helm-charts/iqserver/templates/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
     app: {{ template "iqserver.fullname" . }}
 spec:
   replicas: 1
+  {{- if .Values.deploymentStrategy }}
+  strategy:
+{{ toYaml .Values.deploymentStrategy | indent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ template "iqserver.fullname" . }}

--- a/scripts/templates/nxiq-operator-certified.clusterserviceversion.yaml
+++ b/scripts/templates/nxiq-operator-certified.clusterserviceversion.yaml
@@ -21,6 +21,9 @@ metadata:
                 "command": null
               }
             },
+            "deploymentStrategy": {
+              "type": "Recreate"
+            },
             "fullnameOverride": "",
             "imagePullSecrets": [],
             "ingress": {

--- a/scripts/templates/nxiq-operator-certified.clusterserviceversion.yaml
+++ b/scripts/templates/nxiq-operator-certified.clusterserviceversion.yaml
@@ -238,6 +238,7 @@ spec:
     | `ingress.tls.enabled`                       | Enable TLS                          | `true`                                 |
     | `ingress.tls.secretName`                    | Name of the secret storing TLS cert, `false` to use the Ingress' default certificate | `nexus-tls`                             |
     | `ingress.path`                              | Path for ingress rules. GCP users should set to `/*` | `/`                    |
+    | `deploymentStrategy.type`                   | Deployment Strategy                 |  `Recreate` |
     | `deployment.preStart.command`               | Command to run before starting the IQ Server container  | `nil`                   |
     | `deployment.postStart.command`              | Command to run after starting the IQ Server container  | `nil`                    |
     | `deployment.terminationGracePeriodSeconds` | Time to allow for clean shutdown                        | 120                      |

--- a/scripts/templates/sonatype.com_v1alpha1_nexusiq_cr.yaml
+++ b/scripts/templates/sonatype.com_v1alpha1_nexusiq_cr.yaml
@@ -12,6 +12,8 @@ spec:
       command: null
     preStart:
       command: null
+  deploymentStrategy:
+    type: Recreate
   fullnameOverride: ""
   imagePullSecrets: []
   ingress:

--- a/scripts/templates/values.yaml
+++ b/scripts/templates/values.yaml
@@ -100,7 +100,8 @@ deployment:
   # Uncomment and modify this to run a command after starting the IQ Server
   postStart:
     command:    # '["/bin/sh", "-c", "ls"]'
-
+deploymentStrategy:
+  type: Recreate
 ingress:
   enabled: false
   annotations: {}


### PR DESCRIPTION
Allow new upgraded servers to replace older servesrs by first shutting down and recreating the server on the same storage.

JIRA: https://issues.sonatype.org/browse/INT-6768