### PR TITLE
INT-6832 copy jvm's cacert as basis for keystore.jks

### DIFF
--- a/helm-charts/iqserver/templates/deployment.yaml
+++ b/helm-charts/iqserver/templates/deployment.yaml
@@ -68,11 +68,17 @@ spec:
           command:
             - sh
             - '-c'
-            - 'cd /certs; for c in *; do
-                 keytool -import -alias "$c" -file "$c" -trustcacerts -noprompt
-                   -storepass changeit -keystore /etc/nexus-iq-server/jks/keystore.jks;
+            - 'cp -v /usr/lib/jvm/jre/lib/security/cacerts
+                 /etc/nexus-iq-server/jks/keystore.jks;
+               chmod 644 /etc/nexus-iq-server/jks/keystore.jks;
+               cd /certs; for c in *; do
+                 keytool -import -alias "$c" -file "$c"
+                   -trustcacerts -noprompt
+                   -storepass changeit
+                   -keystore /etc/nexus-iq-server/jks/keystore.jks;
                done;
-               keytool -list -storepass changeit -keystore /etc/nexus-iq-server/jks/keystore.jks'
+               keytool -list -storepass changeit
+                   -keystore /etc/nexus-iq-server/jks/keystore.jks'
           volumeMounts:
             - mountPath: /certs
               name: certificates-volume


### PR DESCRIPTION
if we're going to install our own certs, first copy the JVM's cacerts file, so we still recognize all the public CAs that shipped with java.

This workflow of building upon existing certs is recommended in our help docs for using SSL: https://help.sonatype.com/iqserver/configuring/certificates-and-secure-connections#CertificatesandSecureConnections-HowtoAddaTrustedRemoteCertificatetoaCustomTruststore

JIRA: https://issues.sonatype.org/browse/INT-6832