### PR TITLE
remove the runAs configs

### DIFF
--- a/helm-charts/iqserver/templates/deployment.yaml
+++ b/helm-charts/iqserver/templates/deployment.yaml
@@ -30,9 +30,6 @@ spec:
         image: {{ .Values.iq.imageName }}
         securityContext:
           allowPrivilegeEscalation: false
-          runAsNonRoot: true
-          runAsUser: 1000
-          runAsGroup: 1000
           seccompProfile:
             type: RuntimeDefault
           capabilities:

--- a/helm-charts/iqserver/templates/deployment.yaml
+++ b/helm-charts/iqserver/templates/deployment.yaml
@@ -30,8 +30,6 @@ spec:
         image: {{ .Values.iq.imageName }}
         securityContext:
           allowPrivilegeEscalation: false
-          seccompProfile:
-            type: RuntimeDefault
           capabilities:
             drop:
               - ALL


### PR DESCRIPTION
In preparation of the next release, we're removing the runAs configs, since they've been shown to be incompatible with common SSC configs in nxrm's operator, so removing here as well until we find a better solution.

JIRA: https://issues.sonatype.org/browse/INT-7470